### PR TITLE
remove username from Device string representation

### DIFF
--- a/expo_notifications/models/device.py
+++ b/expo_notifications/models/device.py
@@ -40,4 +40,4 @@ class Device(models.Model):
         )
 
     def __str__(self) -> str:
-        return f"Device #{self.pk} of {self.user.username}"
+        return f"Device #{self.pk} of {self.user}"


### PR DESCRIPTION
Just `self.user` can be used instead of using any attribute on the user. For example, we have modified the user model, so it doesn't have any field named username.